### PR TITLE
replaced deprecated header sys/time.h with chrono for  gettimeofday

### DIFF
--- a/src/memwatch.cc
+++ b/src/memwatch.cc
@@ -15,8 +15,9 @@
 #include <sstream>
 
 #include <math.h> // for pow
-#include <time.h> // for time
+// #include <time.h> // for time
 // #include <sys/time.h>
+#include <chrono>
 
 using namespace v8;
 using namespace node;
@@ -24,8 +25,8 @@ using namespace node;
 Local<Object> g_context;
 
 
-#if defined(_WIN32)
-#include <chrono>
+// #if defined(_WIN32)
+
 
 int gettimeofday(struct timeval* tp, struct timezone* tzp) {
   namespace sc = std::chrono;
@@ -37,7 +38,7 @@ int gettimeofday(struct timeval* tp, struct timezone* tzp) {
   return 0;
 }
 
-#endif // _WIN32
+// #endif // _WIN32
 
 class UponGCCallback : public Nan::AsyncResource {
     public:

--- a/src/memwatch.cc
+++ b/src/memwatch.cc
@@ -15,19 +15,16 @@
 #include <sstream>
 
 #include <math.h> // for pow
-// #include <time.h> // for time
+#include <time.h> // for time
 // #include <sys/time.h>
-#include <chrono>
+#include <chrono> // use chrono instead of sys/time.h
 
 using namespace v8;
 using namespace node;
 
 Local<Object> g_context;
 
-
-// #if defined(_WIN32)
-
-
+// define gettimeofday which uses chrono, earlier it was defined in header sys/time.h which is now deprecated
 int gettimeofday(struct timeval* tp, struct timezone* tzp) {
   namespace sc = std::chrono;
   sc::system_clock::duration d = sc::system_clock::now().time_since_epoch();
@@ -38,7 +35,6 @@ int gettimeofday(struct timeval* tp, struct timezone* tzp) {
   return 0;
 }
 
-// #endif // _WIN32
 
 class UponGCCallback : public Nan::AsyncResource {
     public:

--- a/src/memwatch.cc
+++ b/src/memwatch.cc
@@ -16,12 +16,28 @@
 
 #include <math.h> // for pow
 #include <time.h> // for time
-#include <sys/time.h>
+// #include <sys/time.h>
 
 using namespace v8;
 using namespace node;
 
 Local<Object> g_context;
+
+
+#if defined(_WIN32)
+#include <chrono>
+
+int gettimeofday(struct timeval* tp, struct timezone* tzp) {
+  namespace sc = std::chrono;
+  sc::system_clock::duration d = sc::system_clock::now().time_since_epoch();
+  sc::seconds s = sc::duration_cast<sc::seconds>(d);
+  tp->tv_sec = s.count();
+  tp->tv_usec = sc::duration_cast<sc::microseconds>(d - s).count();
+
+  return 0;
+}
+
+#endif // _WIN32
 
 class UponGCCallback : public Nan::AsyncResource {
     public:


### PR DESCRIPTION
I checked the library works on windows 11, Mac, Ububtu. I specifically checked lib with memwatch listener "leak". It gives results on above three platforms.