### PR TITLE
Fix windows compatibility of memwatch.cc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Unreleased
+	* Fix windows compatibility of memwatch.cc
+
 v2.0.0
 	* BREAKING: Drop support for Node <= 9.
 	* Add support for Node >= 10.

--- a/src/memwatch.cc
+++ b/src/memwatch.cc
@@ -16,7 +16,6 @@
 
 #include <math.h> // for pow
 #include <time.h> // for time
-#include <sys/time.h>
 
 using namespace v8;
 using namespace node;
@@ -176,10 +175,7 @@ NAN_GC_CALLBACK(memwatch::after_gc) {
 
         Nan::GetHeapStatistics(&hs);
 
-        timeval tv;
-        gettimeofday(&tv, NULL);
-
-        baton->gc_ts = (tv.tv_sec * 1000000) + tv.tv_usec;
+        baton->gc_ts = uv_hrtime() / 1000;
 
         baton->total_heap_size = hs.total_heap_size();
         baton->total_heap_size_executable = hs.total_heap_size_executable();

--- a/tests.js
+++ b/tests.js
@@ -2,6 +2,10 @@ const
 should = require('should'),
 memwatch = require('./');
 
+function hrtimeInMicroseconds() {
+  return process.hrtime.bigint() / 1000n;
+}
+
 describe('the library', function() {
   it('should export a couple functions', function(done) {
     should.exist(memwatch.gc);
@@ -14,10 +18,23 @@ describe('the library', function() {
 });
 describe('calling .gc()', function() {
   it('should cause a stats() event to be emitted', function(done) {
+    let timeBeforeGc;
+
     memwatch.once('stats', function(s) {
+      const timeAfterEvent = hrtimeInMicroseconds();
+
       s.should.be.object;
+
+      (typeof timeBeforeGc).should.equal("bigint");
+      timeAfterEvent.should.be.greaterThan(timeBeforeGc);
+
+      s.gc_ts.should.be.a.Number();
+      s.gc_ts.should.be.within(timeBeforeGc, timeAfterEvent);
+
       done();
     });
+
+    timeBeforeGc = hrtimeInMicroseconds();
     memwatch.gc();
   });
 });


### PR DESCRIPTION
Fixes windows compatibility of memwatch.cc which is broken since #3 .
I used `uv_hrtime()` instead of gettimeofday to get `gc_ts` in microseconds.

`npm install` of v1.0.2 and v.2.0.0 shows the following error on a windows machine:

```
C:\work\myproject\node_modules\@airbnb\node-memwatch\src\memwatch.cc(19): fatal error C1083: Cannot open include file: 'sys/time.h': No such file or directory [C:\work\myproject\node_modules\@airbnb\node-memwatch\build\memwatch.vcxproj]
gyp ERR! build error 
gyp ERR! stack Error: `C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\lib\build.js:191:23)
gyp ERR! stack     at ChildProcess.emit (events.js:198:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:248:12)
gyp ERR! System Windows_NT 10.0.19041
gyp ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd C:\work\myproject\node_modules\@airbnb\node-memwatch
gyp ERR! node -v v10.22.0
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.1.3 (node_modules\fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})    

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @airbnb/node-memwatch@2.0.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @airbnb/node-memwatch@2.0.0 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```