### PR TITLE
v3.0.0 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+v3.0.0
+	* BREAKING: Drop support for Node <= 17.
+	* Add support for Node >= 20.
+	* Convert `mocha` tests to `vitest`
+	* Convert CI from Travis.CI to GitHub workflows
+
 v2.0.0
 	* BREAKING: Drop support for Node <= 9.
 	* Add support for Node >= 10.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@airbnb/node-memwatch",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@airbnb/node-memwatch",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@airbnb/node-memwatch",
   "description": "Keep an eye on your memory usage, and discover and isolate leaks.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "Lloyd Hilaiel (http://lloyd.io)",
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
```
v3.0.0
	* BREAKING: Drop support for Node <= 17.
	* Add support for Node >= 20.
	* Convert `mocha` tests to `vitest`
	* Convert CI from Travis.CI to GitHub workflows
```
